### PR TITLE
makes column sorting case insensitive in psql

### DIFF
--- a/lib/fancygrid/view_state.rb
+++ b/lib/fancygrid/view_state.rb
@@ -84,7 +84,7 @@ module Fancygrid#:nodoc:
     
     def sql_order
       return nil unless ordered?
-      return "#{order_table}.#{order_column} #{order_direction}"
+      return "LOWER(#{order_table}.#{order_column}) #{order_direction}"
     end
     
     def pagination

--- a/spec/view_state_spec.rb
+++ b/spec/view_state_spec.rb
@@ -86,6 +86,12 @@ describe Fancygrid::ViewState do
       state = Fancygrid::ViewState.new :order => { :identifier => "a.b" }
       state.ordered?.should be false
     end
+
+    it "sql_order should not be case sensitive" do
+      state = Fancygrid::ViewState.new :order => { :identifier => 'a.b', :direction => 'asc' }
+      state.sql_order.should eql 'LOWER(a.b) asc'
+    end
+
   end
 
 end


### PR DESCRIPTION
This commit is opinionated -- sorting columns should never differentiate by case.

Anyone have a good resource on information on determining how SQL standard compliant, LOWER, is?
