### PR TITLE
fix date sorting in PostgresSQL

### DIFF
--- a/lib/fancygrid/view_state.rb
+++ b/lib/fancygrid/view_state.rb
@@ -6,15 +6,15 @@ module Fancygrid#:nodoc:
   #  ]
   #  :conditions => [
   #    { :identifier => <string>, :operator => <string>, :value => <string> }
-  #  ], 
+  #  ],
   #  :operator => ["all"|"any"],
   #  :order => { :identifier => <string>, :direction => ["asc"|"desc"|""] },
   #  :pagination => { :page => <number>, :per_page => <number> }
-  #}  
+  #}
   class ViewState
-    
+
     attr_accessor :dump
-      
+
     def initialize(dump = {})
       raise ArgumentError, "'dump' must be a Hash" unless dump.is_a? Hash
       self.dump = dump.with_indifferent_access
@@ -23,23 +23,23 @@ module Fancygrid#:nodoc:
       self.fix_order
       self.fix_pagination
     end
-    
+
     def column_options(node)
-      self.dump[:columns].select { |hash| 
-        node.identifier == hash[:identifier] 
+      self.dump[:columns].select { |hash|
+        node.identifier == hash[:identifier]
       }.first || {}
     end
-    
+
     def column_option(node, option, default)
       self.column_options(node).fetch(option, default)
     end
-    
+
     def column_conditions(node)
-      self.dump[:conditions].select { |hash| 
-        node.identifier == hash[:identifier] 
+      self.dump[:conditions].select { |hash|
+        node.identifier == hash[:identifier]
       }.first || {}
     end
-    
+
     def column_condition(node, option, default)
       self.column_conditions(node).fetch(option.to_s, default)
     end
@@ -47,23 +47,23 @@ module Fancygrid#:nodoc:
     def conditions
       self.dump[:conditions]
     end
-        
+
     def operator
       self.dump[:operator]
     end
-    
+
     def conditions_match_all?
       self.dump.fetch(:conditions_match, :any).to_s == "all"
     end
-    
+
     def order
       self.dump.fetch(:order, {})
     end
-    
+
     def order_table
       self.order[:identifier].to_s.split(".").first
     end
-    
+
     def order_column
       self.order[:identifier].to_s.split(".").last
     end
@@ -77,16 +77,16 @@ module Fancygrid#:nodoc:
         self.order_direction
       end
     end
-    
+
     def ordered?
       !(order_table.blank? || order_column.blank? || order_direction.blank?)
     end
-    
+
     def sql_order
       return nil unless ordered?
-      return "#{order_table}.#{order_column} #{order_direction}"
+      return "LOWER(CAST(#{order_table}.#{order_column} AS CHAR)) #{order_direction}"
     end
-    
+
     def pagination
       self.dump.fetch(:pagination, {})
     end
@@ -102,21 +102,21 @@ module Fancygrid#:nodoc:
       return default if result <= 0
       return result
     end
-    
+
     def pagination_options(default_page, default_per_page)
       {
         :page => self.pagination_page(default_page).to_i,
         :per_page => self.pagination_per_page(default_per_page).to_i
       }
     end
-    
+
     def search_visible
       self.dump.fetch(:search_visible, false)
     end
 
     protected
-    # converts the columns option into an array of hashes 
-    # 
+    # converts the columns option into an array of hashes
+    #
     def fix_columns
       h = self.dump
       # conditions may be passed as a hash like { "0" => {}, "1" => {}}
@@ -126,8 +126,8 @@ module Fancygrid#:nodoc:
       # filter out invalid entries.
       h[:columns] = h[:columns].select { |entry| entry.is_a?(Hash) }
     end
-    
-    # converts the conditions options in to an array of hashes 
+
+    # converts the conditions options in to an array of hashes
     # with at least an :identifier and :operator
     #
     #    { :identifier => <string>, :operator => [all|any] }
@@ -142,14 +142,14 @@ module Fancygrid#:nodoc:
       h[:conditions] = h[:conditions].select { |entry| entry.is_a?(Hash) && entry[:identifier].present? && entry[:operator].present? }
       h[:operator] = "all" unless %w(all any).include? h[:operator]
     end
-    
+
     def fix_order
       self.dump[:order] = {} unless self.dump[:order].is_a? Hash
       hash = self.dump[:order]
       hash.delete(:identifier)unless hash[:identifier].is_a? String
       hash.delete(:direction) unless %w(asc desc).include? hash[:direction]
     end
-    
+
     def fix_pagination
       self.dump[:pagination] = {} unless self.dump[:pagination].is_a? Hash
       hash = self.dump[:pagination]


### PR DESCRIPTION
fix for multiple errors in production like this:

```
An ActiveRecord::StatementInvalid occurred in bonds#index:

 PG::UndefinedFunction: ERROR:  function lower(date) does not exist
LINE 1: ...bonds"  WHERE "bonds"."agency_id" = 7291 ORDER BY LOWER(bond...
                                                            ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
: SELECT  bonds.bond_number, bonds.bond_status, bonds.type, bonds.effective_date, bonds.expiration_date, bonds.principal_name, bonds.premium, bonds.commission, bonds.bond_amount FROM "bonds"  WHERE "bonds"."agency_id" = 7291 ORDER BY LOWER(bonds.expiration_date) desc LIMIT 100 OFFSET 300
 vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.19/lib/active_record/connection_adapters/postgresql_adapter.rb:1163:in `async_exec'
```
